### PR TITLE
Improve ci build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,12 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
+    - name: Cache SonarQube packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
     - name: Build with Maven
       run: mvn --errors --batch-mode "-Dsonar.host.url=https://sonarcloud.io" -Dsonar.organization=itsallcode -Dsonar.login=$SONAR_TOKEN clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,12 @@ jobs:
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Build with Maven
-      run: mvn --errors --batch-mode "-Dsonar.host.url=https://sonarcloud.io" -Dsonar.organization=itsallcode -Dsonar.login=$SONAR_TOKEN clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
+      run: mvn --errors --batch-mode clean install
+      env:
+        MAVEN_OPTS: "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+    - name: Sonar analysis
+      if: ${{ env.SONAR_TOKEN != null }}
+      run: mvn --errors --batch-mode -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=itsallcode -Dsonar.login=$SONAR_TOKEN org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         MAVEN_OPTS: "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
     - name: Publish Test Report
       uses: scacap/action-surefire-report@v1
-      if: always()
+      if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
       with:
         report_paths: '**/target/surefire-reports/TEST-*.xml'
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Speedup build by caching sonar packages
- Don't fail build for pull requests from forks
  - Run sonar analysis only when SONAR_TOKEN is available
  - Run test result report step only when GITHUB_TOKEN has write permissions