### PR TITLE
Document Java 11 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The extensions in this project were inspired by a set of JUnit4 rules called "[S
 
 ## Runtime Dependencies
 
+Starting with version 1.2.0 `junit5-system-extensions` requires Java 11 to compile and at runtime. If your project requires Java 8, please use version 1.1.0.
+
 | Dependency                                                                   | Purpose                                                | License                       |
 -------------------------------------------------------------------------------|--------------------------------------------------------|--------------------------------
 | [JUnit5](https://junit.org/junit5/)                                          | Unit test framework                                    | Eclipse Public License v2.0   |

--- a/doc/changes/changes_1.2.0.md
+++ b/doc/changes/changes_1.2.0.md
@@ -8,6 +8,10 @@ When trapping `System.exit` calls, the `ExitGuardSecurityManager` now doesn't si
 
 This way applications that require a security manager don't change their behavior.
 
+## Breaking change
+
+* `junit5-system-extensions` requires Java 11 to compile and at runtime.
+
 ## Features
 
 * [#23](https://github.com/itsallcode/junit5-system-extensions/issues/23): Delegate security manager calls to the original security manager


### PR DESCRIPTION
The requirement for Java 11 was not documented for release 1.2.0 as noted in #26